### PR TITLE
Add confirmation dialog for quitting active exercise

### DIFF
--- a/src/app/pages/training-set/training-set.component.html
+++ b/src/app/pages/training-set/training-set.component.html
@@ -81,3 +81,15 @@
   [workoutName]="currentExerciseSet?.title || ''" 
   (closed)="closeScheduleDialog()">
 </app-schedule-workout>
+
+<!-- Confirmation Dialog -->
+<div *ngIf="showConfirmationDialog" class="fixed inset-0 flex items-center justify-center z-50">
+  <div class="bg-white p-6 rounded-lg shadow-lg">
+    <h2 class="text-lg font-semibold mb-4">Quit Workout</h2>
+    <p class="mb-4">Are you sure you want to quit the workout?</p>
+    <div class="flex justify-end space-x-4">
+      <button (click)="confirmQuit()" class="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors">Yes</button>
+      <button (click)="cancelQuit()" class="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-colors">No</button>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/training-set/training-set.component.ts
+++ b/src/app/pages/training-set/training-set.component.ts
@@ -115,10 +115,14 @@ export class TrainingSetComponent implements OnInit, OnDestroy {
         this.startPreparation(0, true);
       }
     });
+
+    // Add event listener for back button click event
+    window.addEventListener('popstate', this.handleBackButtonClick.bind(this));
   }
 
   ngOnDestroy(): void {
     this.timerService.stop();
+    window.removeEventListener('popstate', this.handleBackButtonClick.bind(this));
   }
 
   private startPreparation(index: number, first: boolean): void {
@@ -216,7 +220,7 @@ export class TrainingSetComponent implements OnInit, OnDestroy {
       this.showAchievementNotification();
     }
     
-    this.router.navigate(['/']);
+    this.showQuitConfirmationDialog();
   }
 
   title(id: number): string {
@@ -268,6 +272,22 @@ export class TrainingSetComponent implements OnInit, OnDestroy {
       this.notificationService.showAchievementNotification(
         `You've completed the ${this.currentExerciseSet.title} workout! Great job!`
       );
+    }
+  }
+
+  // Add method to show confirmation dialog
+  private showQuitConfirmationDialog(): void {
+    const confirmation = window.confirm('Are you sure you want to quit the workout?');
+    if (confirmation) {
+      this.router.navigate(['/']);
+    }
+  }
+
+  // Add method to handle back button click event
+  private handleBackButtonClick(event: PopStateEvent): void {
+    if (this.exercise && this.exercise.state === ExerciseState.Active) {
+      event.preventDefault();
+      this.showQuitConfirmationDialog();
     }
   }
 }


### PR DESCRIPTION
Add confirmation dialog when users click the back button during an active exercise.

* Add event listener for back button click event in `ngOnInit` method and remove it in `ngOnDestroy` method in `src/app/pages/training-set/training-set.component.ts`
* Modify `exitWorkout` method to show the confirmation dialog instead of navigating directly in `src/app/pages/training-set/training-set.component.ts`
* Add `showQuitConfirmationDialog` method to display the confirmation dialog in `src/app/pages/training-set/training-set.component.ts`
* Add `handleBackButtonClick` method to handle the back button click event and show the confirmation dialog in `src/app/pages/training-set/training-set.component.ts`
* Add confirmation dialog HTML structure in `src/app/pages/training-set/training-set.component.html`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/BlockCat/vibe_code_sport_timer_app/pull/1?shareId=27709caf-7ded-4de6-8bfa-608d10d23569).